### PR TITLE
patch: area_type and biomass agg function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gapindex
 Title: Standard AFSC GAP Product Calculations
-Version: 2.1.0
+Version: 2.1.1
 Authors@R: 
     person("Zack", "Oyafuso", , "zack.oyafuso@noaa.gov", role = c("aut", "cre"))
 Description: This package contains functions to calculate standard data products (CPUE, Biomass, Size Composition, and Age Composition) resulting from the NOAA AFSC GAP summer groundfish bottom trawl survey.

--- a/R/calc_agecomp_region.R
+++ b/R/calc_agecomp_region.R
@@ -48,7 +48,7 @@ calc_agecomp_region <- function(racebase_tables,
     subareas <- subset(x = racebase_tables$subarea,
                        subset = SURVEY_DEFINITION_ID == 
                          survey_designs$SURVEY_DEFINITION_ID[isurvey] &
-                         TYPE == "REGION" &
+                         AREA_TYPE == "REGION" &
                          DESIGN_YEAR == survey_designs$DESIGN_YEAR[isurvey])
     
     for (iregion in 1:nrow(x = subareas)) { ## Loop over regions -- start

--- a/R/calc_biomass_subarea.R
+++ b/R/calc_biomass_subarea.R
@@ -86,12 +86,23 @@ calc_biomass_subarea <- function(racebase_tables = NULL,
           
           ## Sum the biomass and abundance across strata in isubarea
           subarea_summed_biomass <- 
-            stats::aggregate(cbind(BIOMASS_MT, 
-                                   POPULATION_COUNT) ~
+            stats::aggregate(BIOMASS_MT ~
                                SPECIES_CODE + YEAR,
                              data = subarea_biomass_by_stratrum,
                              FUN = sum)
-          
+							 
+							         subarea_summed_population <- 
+          stats::aggregate(POPULATION_COUNT ~
+                             SPECIES_CODE + YEAR,
+                           data = subarea_biomass_by_stratrum,
+                           FUN = sum)
+        
+		## Merge Total Biomass and Population
+        subarea_summed_biomass <- merge(x = subarea_summed_biomass,
+                                        y = subarea_summed_population,
+                                        by = c("SPECIES_CODE", "YEAR"),
+                                        all = TRUE) 
+										
           ## Sum the many types of variances across strata in isubarea
           subarea_summed_variance <- 
             stats::aggregate(cbind(CPUE_KGKM2_VAR, CPUE_NOKM2_VAR, 

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -148,18 +148,18 @@ get_data <- function(year_set = c(1996, 1999),
                        WHEN SURVEY_DEFINITION_ID = 78 THEN 'BSS'
                        ELSE NULL
                        END AS SURVEY, ",
-                      "DESIGN_YEAR, AREA_ID, TYPE, AREA_KM2, DESCRIPTION, ",
+                      "DESIGN_YEAR, AREA_ID, AREA_TYPE, AREA_KM2, DESCRIPTION, ",
                       "AREA_NAME FROM GAP_PRODUCTS.AREA",
                       " WHERE SURVEY_DEFINITION_ID IN ", survey_def_ids_vec))
   
   ## Subset stratum info out of `area_info`
   stratum_data <- subset(x = area_info,
-                         subset = TYPE == "STRATUM" & 
+                         subset = AREA_TYPE == "STRATUM" & 
                            DESIGN_YEAR %in% survey_df$DESIGN_YEAR)
   
   ## Subset subarea info out of `area_info`
   subarea_data <- subset(x = area_info,
-                         subset = TYPE != "STRATUM" & 
+                         subset = AREA_TYPE != "STRATUM" & 
                            DESIGN_YEAR %in% survey_df$DESIGN_YEAR)
   
   ## Change "AREA_ID" column name to "STRATUM". 
@@ -172,7 +172,7 @@ get_data <- function(year_set = c(1996, 1999),
   
   subarea_data <- 
     subarea_data[order(subarea_data$SURVEY, subarea_data$AREA_ID),
-                 c("SURVEY_DEFINITION_ID", "SURVEY", "DESIGN_YEAR", "TYPE",
+                 c("SURVEY_DEFINITION_ID", "SURVEY", "DESIGN_YEAR", "AREA_TYPE",
                    "AREA_ID", "AREA_NAME", "DESCRIPTION")]
   
   


### PR DESCRIPTION
Changing calls to the "TYPE" column in GAP_PRODUCTS.AREA to reflect the new name "AREA_TYPE"

Fixed bug that weirdly handled NAs in biomass calculations