### PR TITLE
add keyring

### DIFF
--- a/R/get_connected.R
+++ b/R/get_connected.R
@@ -11,9 +11,6 @@
 
 get_connected <- function(schema = "AFSC") {
   
-  username <- getPass::getPass(msg = "Enter your AFSC Oracle Database Username: ")
-  password <- getPass::getPass(msg = "Enter your AFSC Oracle Database Password: ")
-
    # check if database name is stored in keyring, if not request user/pwd
   if(!(db %in% keyring::key_list()[,1])) {
     username <- getPass::getPass(msg = "Enter your AFSC Oracle Database Username: ")

--- a/R/get_connected.R
+++ b/R/get_connected.R
@@ -13,6 +13,15 @@ get_connected <- function(schema = "AFSC") {
   
   username <- getPass::getPass(msg = "Enter your AFSC Oracle Database Username: ")
   password <- getPass::getPass(msg = "Enter your AFSC Oracle Database Password: ")
+
+   # check if database name is stored in keyring, if not request user/pwd
+  if(!(db %in% keyring::key_list()[,1])) {
+    username <- getPass::getPass(msg = "Enter your AFSC Oracle Database Username: ")
+    password <- getPass::getPass(msg = "Enter your AFSC Oracle Database Password: ")
+  } else {
+    username <- keyring::key_list(db)$username
+    password <-  keyring::key_get(db, keyring::key_list(db)$username)
+  }
   
   suppressWarnings(channel <- RODBC::odbcConnect(dsn = paste(schema), 
                                                  uid = paste(username), 


### PR DESCRIPTION
Seems adding keyring would align the afscdata and gapindex packages a bit more. Or at least assist the memory challenged among us. 

Here is a brief walkthrough https://afsc-assessments.github.io/afscdata/articles/getting-started.html