### PR TITLE
fixed argument names, adding access check

### DIFF
--- a/R/get_connected.R
+++ b/R/get_connected.R
@@ -2,14 +2,16 @@
 #' 
 #' @description Creates the RODBC connection to Oracle needed to pull SQL 
 #' queries from RACE database. Make sure you are connected to the VPN before 
-#' running the function. 
+#' running the function. Also support users who use the Rpackage `keyring` to
+#' store usernames and passwords. 
 #' 
-#' @param schema A registered data source name. To be used as the `dsn` argument in `RODBC::odbcConnect()`
+#' @param db string. A registered data source name, in this case "AFSC" by default. This argument is passed to the  the `dsn` argument in `RODBC::odbcConnect()`
+#' @param check_access boolean. If TRUE (by default), checks whether you have the specific tables in GAP_PRODUCTS, RACEBASE and RACE_DATA used in the gapindex package. Outputs an error if the user does not have access to these tables with a message of the point of contact information for access. 
 #' @return channel of class "RODBC". See `?RODBC::odbcConnect()` for more detail
 #' @export
 #' 
 
-get_connected <- function(schema = "AFSC") {
+get_connected <- function(db = "AFSC", check_access = TRUE) {
   
    # check if database name is stored in keyring, if not request user/pwd
   if(!(db %in% keyring::key_list()[,1])) {
@@ -20,7 +22,7 @@ get_connected <- function(schema = "AFSC") {
     password <-  keyring::key_get(db, keyring::key_list(db)$username)
   }
   
-  suppressWarnings(channel <- RODBC::odbcConnect(dsn = paste(schema), 
+  suppressWarnings(channel <- RODBC::odbcConnect(dsn = paste(db), 
                                                  uid = paste(username), 
                                                  pwd = paste(password), 
                                                  believeNRows = FALSE))
@@ -30,8 +32,49 @@ get_connected <- function(schema = "AFSC") {
   }
   
   if (class(channel) == "RODBC") {
-    cat("Successfully connected to Oracle.\n\n")
-    return(channel)
+    cat("Successfully connected to Oracle.\n")
+    
+    if (check_access) {
+      cat("Checking that you have access to the tables queried in the gapindex package.\n")
+      tables_to_check <- 
+        data.frame(table_name = c(
+          "GAP_PRODUCTS.SURVEY_DESIGN",
+          "GAP_PRODUCTS.AREA",
+          "GAP_PRODUCTS.STRATUM_GROUPS",
+          "GAP_PRODUCTS.TAXONOMIC_CLASSIFICATION",
+          
+          "RACEBASE.CATCH",
+          "RACEBASE.HAUL",
+          "RACEBASE.LENGTH",
+          "RACEBASE.SPECIMEN",
+          
+          "RACE_DATA.CRUISES",
+          "RACE_DATA.SURVEYS",
+          "RACE_DATA.SURVEY_DEFINITIONS",
+          "RACE_DATA.VESSELS"),
+          access = F)
+      
+      for (itable in 1:nrow(x = tables_to_check)) {
+        table_check <- tryCatch(
+          expr = RODBC::sqlFetch(channel = channel,
+                                 sqtable = tables_to_check$table_name[itable], 
+                                 max = 5),
+          error = function(cond) data.frame()
+        )
+        if (nrow(x = table_check) == 5) 
+          tables_to_check$access[itable] <- TRUE
+      }
+      
+      if (all(tables_to_check$access == T)) {
+        cat("Confirming connection to all Oracle tables associated with the gapindex package.\n")
+        return(channel)
+      } else (
+        stop("Cannot connect to these tables in Oracle:\n", 
+             paste0(tables_to_check$table_name[tables_to_check$access == F], 
+                    collapse = "\n"),
+             "\n\nPlease contact afsc.gap.metadata@noaa.gov for access to these tables and then try connecting again.")
+      )
+      
+    }
   }
-  
 }

--- a/man/gapindex-package.Rd
+++ b/man/gapindex-package.Rd
@@ -6,6 +6,8 @@
 \alias{gapindex-package}
 \title{gapindex: Standard AFSC GAP Product Calculations}
 \description{
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
+
 This package contains functions to calculate standard data products (CPUE, Biomass, Size Composition, and Age Composition) resulting from the NOAA AFSC GAP summer groundfish bottom trawl survey.
 }
 \author{

--- a/man/get_connected.Rd
+++ b/man/get_connected.Rd
@@ -4,10 +4,12 @@
 \alias{get_connected}
 \title{Define RODBC connection to Oracle}
 \usage{
-get_connected(schema = "AFSC")
+get_connected(db = "AFSC", check_access = TRUE)
 }
 \arguments{
-\item{schema}{A registered data source name. To be used as the \code{dsn} argument in \code{RODBC::odbcConnect()}}
+\item{db}{string. A registered data source name, in this case "AFSC" by default. This argument is passed to the  the \code{dsn} argument in \code{RODBC::odbcConnect()}}
+
+\item{check_access}{boolean. If TRUE (by default), checks whether you have the specific tables in GAP_PRODUCTS, RACEBASE and RACE_DATA used in the gapindex package. Outputs an error if the user does not have access to these tables with a message of the point of contact information for access.}
 }
 \value{
 channel of class "RODBC". See \code{?RODBC::odbcConnect()} for more detail
@@ -15,5 +17,6 @@ channel of class "RODBC". See \code{?RODBC::odbcConnect()} for more detail
 \description{
 Creates the RODBC connection to Oracle needed to pull SQL
 queries from RACE database. Make sure you are connected to the VPN before
-running the function.
+running the function. Also support users who use the Rpackage \code{keyring} to
+store usernames and passwords.
 }


### PR DESCRIPTION
Modifying `get_connected()` to do a simple query on the tables accessed in `get_data()` to make sure the user has access to those tables before doing anything. Tables checked include:

"GAP_PRODUCTS.SURVEY_DESIGN",
"GAP_PRODUCTS.AREA",
"GAP_PRODUCTS.STRATUM_GROUPS",
 "GAP_PRODUCTS.TAXONOMIC_CLASSIFICATION",
          "RACEBASE.CATCH",
          "RACEBASE.HAUL",
          "RACEBASE.LENGTH",
          "RACEBASE.SPECIMEN",
          "RACE_DATA.CRUISES",
          "RACE_DATA.SURVEYS",
          "RACE_DATA.SURVEY_DEFINITIONS",
          "RACE_DATA.VESSELS"

If the user does not have access, an error will occur, with a message to contact afsc.gap.metadata@noaa.gov for supoort